### PR TITLE
Update registry to support publishing resolved artifacts

### DIFF
--- a/.sqlx/query-3348a8306084f610262ee184b017423fd033b302e103bda4f1b2a9dc67d029b5.json
+++ b/.sqlx/query-3348a8306084f610262ee184b017423fd033b302e103bda4f1b2a9dc67d029b5.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT artifact_json FROM artifacts WHERE artifact_hash = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "artifact_json",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3348a8306084f610262ee184b017423fd033b302e103bda4f1b2a9dc67d029b5"
+}

--- a/.sqlx/query-42d869f65e05b0df5db0f3fd3411daddf2cdcf0d428951180fc5e3947cec5380.json
+++ b/.sqlx/query-42d869f65e05b0df5db0f3fd3411daddf2cdcf0d428951180fc5e3947cec5380.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                    INSERT INTO resolves (input_hash, output_hash, is_canonical)\n                    VALUES (?, ?, TRUE)\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "42d869f65e05b0df5db0f3fd3411daddf2cdcf0d428951180fc5e3947cec5380"
+}

--- a/.sqlx/query-446a6809b898283ffcbde10dc520a500b9ff094822d344b1958eea5c3b162e22.json
+++ b/.sqlx/query-446a6809b898283ffcbde10dc520a500b9ff094822d344b1958eea5c3b162e22.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT artifact_json\n            FROM artifacts\n            WHERE artifact_hash = ?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "artifact_json",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "446a6809b898283ffcbde10dc520a500b9ff094822d344b1958eea5c3b162e22"
+}

--- a/.sqlx/query-5ffd88d834d3d39b046133f8327a1faadd29f03242baac004a359f932830af1e.json
+++ b/.sqlx/query-5ffd88d834d3d39b046133f8327a1faadd29f03242baac004a359f932830af1e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO artifacts (artifact_hash, artifact_json)\n            VALUES (?, ?)\n            ON CONFLICT (artifact_hash) DO NOTHING\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "5ffd88d834d3d39b046133f8327a1faadd29f03242baac004a359f932830af1e"
+}

--- a/.sqlx/query-6de903c1422f23c6081f6917c23f4900c76359102eb3213f999fae91fae1d9b5.json
+++ b/.sqlx/query-6de903c1422f23c6081f6917c23f4900c76359102eb3213f999fae91fae1d9b5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                    INSERT INTO resolves (input_hash, output_hash, is_canonical)\n                    VALUES (?, ?, FALSE)\n                    ON CONFLICT (input_hash, output_hash) DO NOTHING\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "6de903c1422f23c6081f6917c23f4900c76359102eb3213f999fae91fae1d9b5"
+}

--- a/.sqlx/query-720268aa2c5df32e2e933e90d581a40091e85c182d33f90bbc129956fb9b87a2.json
+++ b/.sqlx/query-720268aa2c5df32e2e933e90d581a40091e85c182d33f90bbc129956fb9b87a2.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT output_hash\n            FROM resolves\n            WHERE input_hash = ? AND is_canonical\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "output_hash",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "720268aa2c5df32e2e933e90d581a40091e85c182d33f90bbc129956fb9b87a2"
+}

--- a/.sqlx/query-988a8cade80e713ec6af7e934ca0422169274bf90ec80e96f163370b963a15fc.json
+++ b/.sqlx/query-988a8cade80e713ec6af7e934ca0422169274bf90ec80e96f163370b963a15fc.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT artifact_hash, artifact_json\n            FROM artifacts\n            INNER JOIN resolves\n                ON resolves.output_hash = artifacts.artifact_hash\n            WHERE resolves.input_hash = ? AND resolves.is_canonical\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "artifact_hash",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "artifact_json",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "988a8cade80e713ec6af7e934ca0422169274bf90ec80e96f163370b963a15fc"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "brioche"
 version = "0.0.1"
-source = "git+https://github.com/brioche-dev/brioche.git#c46351d60f99655a64426dfbaca5cd21d0dcec34"
+source = "git+https://github.com/brioche-dev/brioche.git#af4722e0e9aff91f8edd84b86d1e20dd9634dbb6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "brioche-pack"
 version = "0.0.1"
-source = "git+https://github.com/brioche-dev/brioche.git#c46351d60f99655a64426dfbaca5cd21d0dcec34"
+source = "git+https://github.com/brioche-dev/brioche.git#af4722e0e9aff91f8edd84b86d1e20dd9634dbb6"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "axum-extra",
+ "blake3",
  "brioche",
  "bytes",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "brioche"
 version = "0.0.1"
-source = "git+https://github.com/brioche-dev/brioche.git#9b4e8b75aba29f7e4fa8a7f821cdcabf1e86267e"
+source = "git+https://github.com/brioche-dev/brioche.git#c46351d60f99655a64426dfbaca5cd21d0dcec34"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "brioche-pack"
 version = "0.0.1"
-source = "git+https://github.com/brioche-dev/brioche.git#9b4e8b75aba29f7e4fa8a7f821cdcabf1e86267e"
+source = "git+https://github.com/brioche-dev/brioche.git#c46351d60f99655a64426dfbaca5cd21d0dcec34"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ argon2 = { version = "0.5.3", features = ["std"] }
 async-trait = "0.1.79"
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["tracing", "typed-header"] }
+blake3 = "1.5.1"
 brioche = { git = "https://github.com/brioche-dev/brioche.git" }
 bytes = "1.6.0"
 clap = { version = "4.5.4", features = ["derive"] }

--- a/migrations/20240414091629_artifacts_and_resolves.sql
+++ b/migrations/20240414091629_artifacts_and_resolves.sql
@@ -1,0 +1,19 @@
+CREATE TABLE artifacts (
+    artifact_hash TEXT PRIMARY KEY NOT NULL,
+    artifact_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+) STRICT;
+
+CREATE TABLE resolves (
+    id INTEGER PRIMARY KEY NOT NULL,
+    input_hash TEXT NOT NULL REFERENCES artifacts (artifact_hash),
+    output_hash TEXT NOT NULL REFERENCES artifacts (artifact_hash),
+    is_canonical BOOLEAN,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX resolves_input_hash_is_canonical
+ON resolves (input_hash, output_hash, is_canonical);
+
+CREATE UNIQUE INDEX resolves_input_hash_output_hash
+ON resolves (input_hash, output_hash);

--- a/src/server.rs
+++ b/src/server.rs
@@ -462,12 +462,10 @@ async fn put_blob_handler(
         }
     }
 
-    // TODO: Compare directly
-    let expected_hash_string = blob_id.to_string();
     let actual_hash = hasher.finalize();
-    let actual_hash_string = actual_hash.to_hex().to_string();
+    let actual_blob_id = BlobId::from_blake3(actual_hash);
 
-    if expected_hash_string != actual_hash_string {
+    if blob_id != actual_blob_id {
         state
             .object_store
             .abort_multipart(&blob_path, &multipart_id)
@@ -477,8 +475,7 @@ async fn put_blob_handler(
             })
             .map_err(ServerError::other)?;
         return Err(ServerError::BadRequest(Cow::Owned(format!(
-            "blob hash mismatch: expected {}, got {}",
-            expected_hash_string, actual_hash_string
+            "blob hash mismatch: expected {blob_id}, got {actual_blob_id}"
         ))));
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,10 +4,13 @@ use argon2::PasswordVerifier;
 use axum::body::Body;
 use axum_extra::headers::{authorization::Basic, Authorization};
 use brioche::{
-    artifact::{ArtifactHash, LazyArtifact},
+    artifact::{ArtifactHash, CompleteArtifact, LazyArtifact},
     blob::BlobId,
     project::{Project, ProjectHash, ProjectListing},
-    registry::{GetProjectTagResponse, PublishProjectResponse, UpdatedTag},
+    registry::{
+        CreateResolveRequest, CreateResolveResponse, GetProjectTagResponse, GetResolveResponse,
+        PublishProjectResponse, UpdatedTag,
+    },
 };
 use eyre::{Context as _, OptionExt as _};
 use futures::StreamExt as _;
@@ -50,6 +53,10 @@ pub async fn start_server(
         .route(
             "/v0/artifacts/:artifact_hash",
             axum::routing::get(get_artifact_handler).put(put_artifact_handler),
+        )
+        .route(
+            "/v0/artifacts/:artifact_hash/resolve",
+            axum::routing::get(get_resolve_handler).post(create_resolve_handler),
         )
         .layer(trace_layer)
         .with_state(state.clone());
@@ -558,6 +565,197 @@ async fn put_artifact_handler(
     } else {
         Ok((axum::http::StatusCode::CREATED, axum::Json(artifact_hash)))
     }
+}
+
+async fn get_resolve_handler(
+    axum::extract::State(state): axum::extract::State<Arc<ServerState>>,
+    axum::extract::Path(artifact_hash): axum::extract::Path<ArtifactHash>,
+) -> Result<axum::Json<GetResolveResponse>, ServerError> {
+    let mut db_transaction = state.db_pool.begin().await.map_err(ServerError::other)?;
+
+    let artifact_hash_value = artifact_hash.to_string();
+    let record = sqlx::query!(
+        r#"
+            SELECT artifact_hash, artifact_json
+            FROM artifacts
+            INNER JOIN resolves
+                ON resolves.output_hash = artifacts.artifact_hash
+            WHERE resolves.input_hash = ? AND resolves.is_canonical
+        "#,
+        artifact_hash_value,
+    )
+    .fetch_optional(&mut *db_transaction)
+    .await
+    .map_err(ServerError::other)?;
+
+    db_transaction.commit().await.map_err(ServerError::other)?;
+
+    let Some(record) = record else {
+        return Err(ServerError::NotFound);
+    };
+
+    let output_artifact: CompleteArtifact = serde_json::from_str(&record.artifact_json)
+        .wrap_err_with(|| format!("failed to deserialize artifact JSON with hash {artifact_hash}"))
+        .map_err(ServerError::other)?;
+    let record_artifact_hash: Result<ArtifactHash, _> = record.artifact_hash.parse();
+    let record_artifact_hash = record_artifact_hash
+        .map_err(|error| eyre::eyre!(error))
+        .wrap_err_with(|| format!("failed to parse artifact hash {}", record.artifact_hash))
+        .map_err(ServerError::other)?;
+
+    if output_artifact.hash() != record_artifact_hash {
+        return Err(ServerError::Other(eyre::eyre!(
+            "artifact hash {} did not match expected hash {record_artifact_hash}",
+            output_artifact.hash(),
+        )));
+    }
+
+    let response = GetResolveResponse {
+        output_hash: output_artifact.hash(),
+        output_artifact,
+    };
+    Ok(axum::Json(response))
+}
+
+async fn create_resolve_handler(
+    Authenticated(state): Authenticated,
+    axum::extract::Path(input_hash): axum::extract::Path<ArtifactHash>,
+    axum::Json(request): axum::Json<CreateResolveRequest>,
+) -> Result<(axum::http::StatusCode, axum::Json<CreateResolveResponse>), ServerError> {
+    let mut db_transaction = state.db_pool.begin().await.map_err(ServerError::other)?;
+
+    let input_hash_value = input_hash.to_string();
+    let input_result = sqlx::query!(
+        r#"
+            SELECT artifact_json
+            FROM artifacts
+            WHERE artifact_hash = ?
+        "#,
+        input_hash_value,
+    )
+    .fetch_optional(&mut *db_transaction)
+    .await
+    .map_err(ServerError::other)?;
+
+    let Some(input_result) = input_result else {
+        return Err(ServerError::NotFound);
+    };
+
+    let input_artifact: LazyArtifact = serde_json::from_str(&input_result.artifact_json)
+        .wrap_err_with(|| {
+            format!("failed to deserialize input artifact JSON with hash {input_hash}")
+        })
+        .map_err(ServerError::other)?;
+    if input_artifact.hash() != input_hash {
+        return Err(ServerError::Other(eyre::eyre!(
+            "artifact hash {} did not match expected hash {input_hash}",
+            input_artifact.hash()
+        )));
+    }
+
+    let output_hash = request.output_hash;
+    let output_hash_value = output_hash.to_string();
+    let output_result = sqlx::query!(
+        r#"
+            SELECT artifact_json
+            FROM artifacts
+            WHERE artifact_hash = ?
+        "#,
+        output_hash_value,
+    )
+    .fetch_optional(&mut *db_transaction)
+    .await
+    .map_err(ServerError::other)?;
+
+    let Some(output_result) = output_result else {
+        return Err(ServerError::BadRequest(Cow::Owned(format!(
+            "output artifact {output_hash} does not exist"
+        ))));
+    };
+
+    let output_artifact: LazyArtifact = serde_json::from_str(&output_result.artifact_json)
+        .wrap_err_with(|| {
+            format!("failed to deserialize output artifact JSON with hash {output_hash}")
+        })
+        .map_err(ServerError::other)?;
+    let _output_artifact: CompleteArtifact = output_artifact.try_into().map_err(|_| {
+        ServerError::BadRequest(Cow::Owned(format!(
+            "output artifact {output_hash} is not a complete artifact"
+        )))
+    })?;
+
+    let canonical_result = sqlx::query!(
+        r#"
+            SELECT output_hash
+            FROM resolves
+            WHERE input_hash = ? AND is_canonical
+        "#,
+        input_hash_value,
+    )
+    .fetch_optional(&mut *db_transaction)
+    .await
+    .map_err(ServerError::other)?;
+
+    let (canonical_output_hash, is_new) = match canonical_result {
+        Some(canonical_result) => {
+            let canonical_output_hash: Result<ArtifactHash, _> =
+                canonical_result.output_hash.parse();
+            let canonical_output_hash = canonical_output_hash
+                .map_err(|error| eyre::eyre!(error))
+                .map_err(ServerError::other)?;
+
+            let insert_result = sqlx::query!(
+                r#"
+                    INSERT INTO resolves (input_hash, output_hash, is_canonical)
+                    VALUES (?, ?, FALSE)
+                    ON CONFLICT (input_hash, output_hash) DO NOTHING
+                "#,
+                input_hash_value,
+                output_hash_value,
+            )
+            .execute(&mut *db_transaction)
+            .await
+            .map_err(ServerError::other)?;
+
+            if insert_result.rows_affected() > 0 {
+                tracing::info!(%input_hash, %output_hash, "added resolve (non-canonical)");
+                (canonical_output_hash, true)
+            } else {
+                tracing::info!(%input_hash, %output_hash, "received resolve, but already exists (non-canonical)");
+                (canonical_output_hash, false)
+            }
+        }
+        None => {
+            sqlx::query!(
+                r#"
+                    INSERT INTO resolves (input_hash, output_hash, is_canonical)
+                    VALUES (?, ?, TRUE)
+                "#,
+                input_hash_value,
+                output_hash_value,
+            )
+            .execute(&mut *db_transaction)
+            .await
+            .map_err(ServerError::other)?;
+
+            tracing::info!(%input_hash, %output_hash, "added resolve (canonical)");
+
+            (output_hash, true)
+        }
+    };
+
+    db_transaction.commit().await.map_err(ServerError::other)?;
+
+    let status = if is_new {
+        axum::http::StatusCode::CREATED
+    } else {
+        axum::http::StatusCode::OK
+    };
+    let response = CreateResolveResponse {
+        canonical_output_hash,
+    };
+
+    Ok((status, axum::Json(response)))
 }
 
 struct Authenticated(Arc<ServerState>);


### PR DESCRIPTION
This PR updates the registry with some new endpoints that allow for publishing resolved artifacts. Namely:

- `PUT /v0/blobs/:blob_id`: Allows uploading a single blob directly (previously, this was only possible through a project
- `PUT /v0/artifacts/:artifact_hash`: Allows uploading the JSON for an artifact
- `GET /v0/artifacts/:artifact_hash`: Allows querying the JSON for an artifact by ID
- `POST /v0/artifacts/:artifact_hash/resolve`: Allows setting the output artifact hash for a given artifact (e.g. what the artifact resolves to). There can be multiple resolves per artifact hash, but the first one is considered "canonical" (the rest are stored but never returned).
- `GET /v0/artifacts/:artifact_hash/resolve`: Get the output artifact hash and JSON for a given artifact. This only returns the canonical resolve for an input artifact hash.

There's also a migration to add the new `artifacts` and `resolves` tables.