### PR TITLE
Implement custom object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,380 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "aws-config"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a89e0000cde82447155d64eeb71720b933b4396a6fbbebad3f8b4f88ca7b54"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4963ac9ff2d33a4231b3806c1c69f578f221a9cabb89ad2bde62ce2b442c8a7"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4576ae7eb91e4d0ca76a3b443c3be979322fc01836cad7908534ae507fa41d99"
+dependencies = [
+ "ahash 0.8.11",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.10.8",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fcc572fd5c58489ec205ec3e4e5f7d63018898a485cbf922a462af496bc300"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b6275fa8684a1192754221173b1f7a7c1260d6b0571cc2b8af09468eb0cffe5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30acd58272fd567e4853c5075d838be1626b59057e0249c9be5a1a7eb13bf70f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d6f29688a4be9895c0ba8bef861ad0c0dac5c15e9618b9b7a6c233990fc263"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "p256",
+ "percent-encoding",
+ "ring",
+ "sha2 0.10.8",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fa43bc04a6b2441968faeab56e68da3812f978a670a5db32accbdcafddd12f"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.8",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f10fa66956f01540051b0aa7ad54574640f748f9839e843442d99b970d3aff9"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de34bcfa1fb3c82a80e252a753db34a6658e07f23d3a5b3fc96919518fa7a3f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.0",
+ "hyper 0.14.28",
+ "hyper-rustls",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc56a5c96ec741de6c5e6bf1ce6948be969d6506dfa9c39cffc284e31e4979b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe14dceea1e70101d38fbf2a99e6a34159477c0fb95e68e05c66bd7ae4c3729"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.0",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872c68cf019c0e4afc5de7753c4f7288ce4b71663212771bf5e4542eb9346ca9"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a43b56df2c529fe44cb4d92bd64d0479883fb9608ff62daede4df5405381814"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 0.2.12",
+ "rustc_version 0.4.0",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +791,16 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -886,6 +1276,8 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
  "axum 0.7.5",
  "axum-extra",
  "blake3",
@@ -898,8 +1290,8 @@ dependencies = [
  "envy",
  "eyre",
  "futures",
+ "http-body-util",
  "joinery",
- "object_store",
  "serde",
  "serde_json",
  "serde_with",
@@ -954,6 +1346,16 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bzip2"
@@ -1186,6 +1588,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32c"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+dependencies = [
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1661,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1473,6 +1906,16 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
@@ -1577,12 +2020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,12 +2054,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 1.6.4",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8 0.9.0",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1691,6 +2160,16 @@ name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -1948,6 +2427,17 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -2217,7 +2707,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
 ]
@@ -2597,6 +3089,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,37 +3410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object_store"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "chrono",
- "futures",
- "humantime",
- "hyper 0.14.28",
- "itertools 0.12.1",
- "md-5",
- "parking_lot 0.12.1",
- "percent-encoding",
- "quick-xml",
- "rand",
- "reqwest",
- "ring",
- "rustls-pemfile 2.1.1",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "tracing",
- "url",
- "walkdir",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,6 +3583,17 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "parking_lot"
@@ -3373,9 +3860,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.9",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -3384,8 +3881,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3559,16 +4056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-xml"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,6 +4165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,8 +4216,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3793,6 +4285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3819,10 +4322,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -3925,7 +4428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -3938,22 +4441,6 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
-dependencies = [
- "base64 0.21.7",
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -4065,6 +4552,20 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4375,6 +4876,16 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
@@ -4426,28 +4937,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snafu"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,12 +4979,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
 ]
 
 [[package]]
@@ -4550,7 +5049,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -5645,7 +6144,7 @@ dependencies = [
  "pin-project",
  "prost 0.11.9",
  "rustls-native-certs",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -6059,6 +6558,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -6521,6 +7026,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xz2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "brioche"
 version = "0.0.1"
-source = "git+https://github.com/brioche-dev/brioche.git#af4722e0e9aff91f8edd84b86d1e20dd9634dbb6"
+source = "git+https://github.com/brioche-dev/brioche.git#b117a0a868b29ab9943d9413a3f0a63116e39ed6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "brioche-pack"
 version = "0.0.1"
-source = "git+https://github.com/brioche-dev/brioche.git#af4722e0e9aff91f8edd84b86d1e20dd9634dbb6"
+source = "git+https://github.com/brioche-dev/brioche.git#b117a0a868b29ab9943d9413a3f0a63116e39ed6"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 argon2 = { version = "0.5.3", features = ["std"] }
 async-trait = "0.1.79"
+aws-config = "1.2.0"
+aws-sdk-s3 = "1.23.0"
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["tracing", "typed-header"] }
 blake3 = "1.5.1"
@@ -20,8 +22,8 @@ dotenvy = "0.15.7"
 envy = "0.4.2"
 eyre = "0.6.12"
 futures = "0.3.30"
+http-body-util = "0.1.1"
 joinery = "3.1.0"
-object_store = { version = "0.9.1", features = ["aws", "azure", "gcp", "http"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 serde_with = "3.7.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use eyre::Context as _;
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
+mod object_store;
 mod server;
 
 #[derive(Debug, Parser)]

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -1,0 +1,620 @@
+use axum::response::IntoResponse as _;
+use eyre::{Context as _, ContextCompat, OptionExt as _};
+use futures::{StreamExt as _, TryStreamExt as _};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+#[derive(Debug, Clone)]
+pub enum ObjectStore {
+    S3 {
+        client: aws_sdk_s3::Client,
+        bucket: String,
+        prefix: String,
+    },
+    Filesystem {
+        path: std::path::PathBuf,
+    },
+}
+
+impl ObjectStore {
+    pub async fn from_url(url: &url::Url) -> eyre::Result<Self> {
+        match url.scheme() {
+            "s3" => {
+                let bucket = url.host_str().wrap_err("no bucket specified in URL")?;
+                let prefix_path = url.path().trim_start_matches('/').to_string();
+                let prefix = if prefix_path.is_empty() {
+                    "".to_string()
+                } else {
+                    format!("{}/", prefix_path)
+                };
+                let aws_config =
+                    aws_config::load_defaults(aws_config::BehaviorVersion::v2023_11_09()).await;
+                let client = aws_sdk_s3::Client::new(&aws_config);
+                Ok(Self::S3 {
+                    client,
+                    bucket: bucket.to_string(),
+                    prefix,
+                })
+            }
+            "file" => {
+                let path = url
+                    .to_file_path()
+                    .map_err(|_| eyre::eyre!("invalid file URL"))?;
+                Ok(Self::Filesystem { path })
+            }
+            "relative-file" => {
+                let relative_path = url.path();
+                let relative_path = relative_path.strip_prefix('/').unwrap_or(relative_path);
+                let abs_path = tokio::fs::canonicalize(std::path::Path::new(relative_path))
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to canonicalize relative object store path: {relative_path}"
+                        )
+                    })?;
+
+                Ok(Self::Filesystem { path: abs_path })
+            }
+            scheme => {
+                eyre::bail!("unsupported scheme {scheme} for object store URL {url}");
+            }
+        }
+    }
+
+    pub async fn exists(&self, key: &str) -> eyre::Result<bool> {
+        match self {
+            ObjectStore::S3 {
+                client,
+                bucket,
+                prefix,
+            } => {
+                let object_key = format!("{prefix}{key}");
+                let response = client
+                    .head_object()
+                    .bucket(bucket)
+                    .key(&object_key)
+                    .send()
+                    .await;
+                match response {
+                    Ok(_) => Ok(true),
+                    Err(aws_sdk_s3::error::SdkError::ServiceError(context))
+                        if matches!(
+                            context.err(),
+                            aws_sdk_s3::operation::head_object::HeadObjectError::NotFound(_)
+                        ) =>
+                    {
+                        Ok(false)
+                    }
+                    Err(error) => Err(error.into()),
+                }
+            }
+            ObjectStore::Filesystem { path } => {
+                let object_path = path.join(key);
+                Ok(tokio::fs::try_exists(object_path).await?)
+            }
+        }
+    }
+
+    pub async fn get_as_http_response(&self, key: &str) -> eyre::Result<axum::response::Response> {
+        match self {
+            ObjectStore::S3 {
+                client,
+                bucket,
+                prefix,
+            } => {
+                let object_key = format!("{prefix}{key}");
+
+                let presigning_config = aws_sdk_s3::presigning::PresigningConfig::builder()
+                    .expires_in(std::time::Duration::from_secs(60 * 60))
+                    .build()?;
+                let presigned_request = client
+                    .get_object()
+                    .bucket(bucket)
+                    .key(&object_key)
+                    .presigned(presigning_config)
+                    .await?;
+
+                eyre::ensure!(
+                    presigned_request.method().to_ascii_lowercase() == "get",
+                    "presigned URL has unexpected method {}",
+                    presigned_request.method()
+                );
+                eyre::ensure!(
+                    presigned_request.headers().count() == 0,
+                    "presigned request has extra required headers",
+                );
+
+                let response = axum::response::Redirect::to(presigned_request.uri());
+                Ok(response.into_response())
+            }
+            ObjectStore::Filesystem { path } => {
+                let object_path = path.join(key);
+                let file = tokio::fs::File::open(&object_path).await?;
+                let file_stream = tokio_util::io::ReaderStream::new(file);
+                Ok(axum::response::Response::new(
+                    axum::body::Body::from_stream(file_stream),
+                ))
+            }
+        }
+    }
+
+    pub async fn put_and_validate<E>(
+        &self,
+        key: &str,
+        input: impl futures::Stream<Item = Result<bytes::Bytes, E>>,
+        expected_hash: blake3::Hash,
+    ) -> eyre::Result<()>
+    where
+        eyre::Error: From<E>,
+    {
+        match self {
+            ObjectStore::S3 {
+                client,
+                bucket,
+                prefix,
+            } => {
+                let object_key = format!("{prefix}{key}");
+
+                let input = std::pin::pin!(input);
+                let upload_type = s3_upload_type(input).await?;
+
+                match upload_type {
+                    S3UploadType::Single(bytes) => {
+                        upload_s3_single_part(client, bucket, &object_key, bytes, expected_hash)
+                            .await?;
+                    }
+                    S3UploadType::Multipart(stream) => {
+                        upload_s3_multipart(client, bucket, &object_key, stream, expected_hash)
+                            .await?;
+                    }
+                }
+
+                Ok(())
+            }
+            ObjectStore::Filesystem { path } => {
+                let object_path = path.join(key);
+                let parent_path = object_path.parent().ok_or_eyre("no parent path")?;
+
+                // Ensure the destination path exists
+                tokio::fs::create_dir_all(&parent_path).await?;
+
+                // Create a temporary file. It's created in the same directory
+                // as the final file to ensure we can rename it without
+                // copying across filesystems.
+                let temp_path = parent_path.join(format!("._tmp_{}", ulid::Ulid::new()));
+
+                let temp_file = tokio::fs::File::create(&temp_path).await?;
+                let mut buf_writer = tokio::io::BufWriter::new(temp_file);
+
+                let buf_writer = std::pin::pin!(&mut buf_writer);
+
+                let result = write_file_and_validate_hash(buf_writer, input, expected_hash).await;
+
+                match result {
+                    Ok(()) => {
+                        // Move the file to its final location if the file
+                        // was written and validated
+                        tokio::fs::rename(&temp_path, &object_path).await?;
+                    }
+                    Err(error) => {
+                        // Remove the temp file if there was an error
+                        let _ = tokio::fs::remove_file(&temp_path).await.inspect_err(|error| {
+                            tracing::warn!(temp_path = %temp_path.display(), %error, "failed to remove temporary file");
+                        });
+
+                        return Err(error);
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+pub async fn write_file_and_validate_hash<W, E>(
+    mut writer: std::pin::Pin<&mut W>,
+    input: impl futures::Stream<Item = Result<bytes::Bytes, E>>,
+    expected_hash: blake3::Hash,
+) -> eyre::Result<()>
+where
+    W: tokio::io::AsyncWrite + Send,
+    eyre::Error: From<E>,
+{
+    let mut hasher = blake3::Hasher::new();
+
+    // Hash and write each set of bytes from the input stream
+    let mut input = std::pin::pin!(input);
+    while let Some(bytes) = input.try_next().await? {
+        hasher.update(&bytes[..]);
+        writer.write_all(&bytes[..]).await?;
+    }
+
+    // Flush and shutdown the writer to ensure the bytes get written
+    writer.flush().await?;
+    writer.shutdown().await?;
+
+    // Validate the hashes match
+    let actual_hash = hasher.finalize();
+    if actual_hash != expected_hash {
+        eyre::bail!("hash mismatch: expected {expected_hash}, got {actual_hash}");
+    }
+
+    Ok(())
+}
+
+enum S3UploadType<S> {
+    Single(bytes::Bytes),
+    Multipart(S),
+}
+
+/// The minimum size for each part of a multipart upload. If the total
+/// request size is small enough to fit within one part, we'll use a normal
+/// upload instead of a multipart upload.
+const MIN_UPLOAD_PART_SIZE: usize = 10 * 1024 * 1024;
+
+async fn s3_upload_type<E>(
+    mut input: impl futures::Stream<Item = Result<bytes::Bytes, E>> + Unpin,
+) -> eyre::Result<S3UploadType<impl futures::Stream<Item = Result<bytes::Bytes, E>>>>
+where
+    eyre::Error: From<E>,
+{
+    let mut buffer = bytes::BytesMut::new();
+
+    while let Some(chunk) = input.try_next().await? {
+        buffer.extend(chunk);
+
+        if buffer.len() > MIN_UPLOAD_PART_SIZE {
+            break;
+        }
+    }
+
+    if buffer.len() > MIN_UPLOAD_PART_SIZE {
+        let stream = futures::stream::once(async move { Ok(buffer.freeze()) }).chain(input);
+        Ok(S3UploadType::Multipart(stream))
+    } else {
+        Ok(S3UploadType::Single(buffer.freeze()))
+    }
+}
+
+async fn upload_s3_single_part(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    key: &str,
+    bytes: bytes::Bytes,
+    expected_hash: blake3::Hash,
+) -> eyre::Result<()> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&bytes[..]);
+    let actual_hash = hasher.finalize();
+    if actual_hash != expected_hash {
+        eyre::bail!("hash mismatch: expected {expected_hash}, got {actual_hash}");
+    }
+
+    let body = http_body_util::Full::new(bytes);
+    let body = aws_sdk_s3::primitives::ByteStream::from_body_1_x(body);
+    client
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(body)
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+async fn upload_s3_multipart<E>(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    key: &str,
+    input: impl futures::Stream<Item = Result<bytes::Bytes, E>>,
+    expected_hash: blake3::Hash,
+) -> eyre::Result<()>
+where
+    eyre::Error: From<E>,
+{
+    let multipart_response = client
+        .create_multipart_upload()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await?;
+    let multipart_upload_id = multipart_response
+        .upload_id
+        .ok_or_eyre("no multipart upload ID returned")?;
+
+    let result = upload_s3_parts_and_validate_hash(
+        client,
+        bucket,
+        key,
+        &multipart_upload_id,
+        input,
+        expected_hash,
+    )
+    .await;
+
+    match result {
+        Ok(parts) => {
+            // Complete the multipart upload if it was successful
+            client
+                .complete_multipart_upload()
+                .bucket(bucket)
+                .key(key)
+                .upload_id(&multipart_upload_id)
+                .multipart_upload(
+                    aws_sdk_s3::types::CompletedMultipartUpload::builder()
+                        .set_parts(Some(parts))
+                        .build(),
+                )
+                .send()
+                .await
+                .wrap_err("failed to complete multipart upload")?;
+        }
+        Err(error) => {
+            // Abort the multipart upload if there was an error
+            let _ = client
+                .abort_multipart_upload()
+                .bucket(bucket)
+                .key(key)
+                .upload_id(&multipart_upload_id)
+                .send()
+                .await
+                .inspect_err(|error| tracing::warn!(%error, "failed to abort multipart upload"));
+
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}
+
+async fn upload_s3_parts_and_validate_hash<E>(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    key: &str,
+    upload_id: &str,
+    input: impl futures::Stream<Item = Result<bytes::Bytes, E>>,
+    expected_hash: blake3::Hash,
+) -> eyre::Result<Vec<aws_sdk_s3::types::CompletedPart>>
+where
+    eyre::Error: From<E>,
+{
+    // Create a reader for the input stream
+    let input = input.map_err(|err| std::io::Error::other(eyre::Error::from(err)));
+    let input_reader = tokio_util::io::StreamReader::new(input);
+    let mut input_reader = std::pin::pin!(input_reader);
+
+    let mut hasher = blake3::Hasher::new();
+    let mut parts = vec![];
+
+    let mut buffer = vec![0; MIN_UPLOAD_PART_SIZE];
+    for part_number in 1.. {
+        // Read a chunk from the receiver, up to the buffer size
+        let chunk_len = read_chunk(&mut input_reader, &mut buffer).await?;
+        let chunk_bytes = &buffer[..chunk_len];
+
+        // A length of 0 means we've reached the end
+        if chunk_len == 0 {
+            break;
+        }
+
+        // Hash the chunk
+        hasher.update(chunk_bytes);
+
+        // Upload the chunk
+        let chunk_body = http_body_util::Full::new(bytes::Bytes::copy_from_slice(chunk_bytes));
+        let chunk_body = aws_sdk_s3::primitives::ByteStream::from_body_1_x(chunk_body);
+        let response = client
+            .upload_part()
+            .bucket(bucket)
+            .key(key)
+            .upload_id(upload_id)
+            .part_number(part_number)
+            .body(chunk_body)
+            .send()
+            .await?;
+
+        parts.push(
+            aws_sdk_s3::types::CompletedPart::builder()
+                .part_number(part_number)
+                .set_e_tag(response.e_tag)
+                .build(),
+        );
+    }
+
+    // Validate the hashes match
+    let actual_hash = hasher.finalize();
+    if actual_hash != expected_hash {
+        eyre::bail!("hash mismatch: expected {expected_hash}, got {actual_hash}");
+    }
+
+    Ok(parts)
+}
+
+/// Repeatedly read from the reader to fill the buffer, returning the
+/// number of bytes read. This function is like `.read_exact()`, except
+/// reaching end-of-file will return `Ok` with the number of bytes successfully read.
+async fn read_chunk(
+    mut reader: impl tokio::io::AsyncRead + Unpin,
+    mut buffer: &mut [u8],
+) -> std::io::Result<usize> {
+    let mut total_length = 0;
+
+    loop {
+        // If there's no more room in the buffer, return
+        if buffer.is_empty() {
+            return Ok(total_length);
+        }
+
+        // Read a part into the buffer
+        let length = reader.read(buffer).await?;
+
+        // If we read 0 bytes, then the reader finished and we can return
+        if length == 0 {
+            return Ok(total_length);
+        }
+
+        // Advance the buffer past the part we just read
+        (_, buffer) = buffer.split_at_mut(length);
+        total_length += length;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream::TryStreamExt as _;
+    use tokio::io::AsyncReadExt as _;
+
+    #[tokio::test]
+    async fn test_s3_upload_type_small() {
+        let input = futures::stream::iter([eyre::Ok(bytes::Bytes::from("hello"))]);
+        let input = std::pin::pin!(input);
+        let upload_type = super::s3_upload_type(input).await.unwrap();
+
+        let super::S3UploadType::Single(bytes) = upload_type else {
+            panic!("expected single upload type");
+        };
+
+        assert_eq!(bytes, bytes::Bytes::from("hello"));
+    }
+
+    #[tokio::test]
+    async fn test_s3_upload_type_small_with_chunks() {
+        let input = futures::stream::iter([
+            eyre::Ok(bytes::Bytes::from("hello")),
+            eyre::Ok(bytes::Bytes::from("world")),
+        ]);
+        let input = std::pin::pin!(input);
+        let upload_type = super::s3_upload_type(input).await.unwrap();
+
+        let super::S3UploadType::Single(bytes) = upload_type else {
+            panic!("expected single upload type");
+        };
+
+        assert_eq!(bytes, bytes::Bytes::from("helloworld"));
+    }
+
+    #[tokio::test]
+    async fn test_s3_upload_type_large() {
+        let content = "hello".repeat(1024 * 1024 * 5);
+        let input = futures::stream::iter([eyre::Ok(bytes::Bytes::from(content.clone()))]);
+        let input = std::pin::pin!(input);
+        let upload_type = super::s3_upload_type(input).await.unwrap();
+
+        let super::S3UploadType::Multipart(stream) = upload_type else {
+            panic!("expected multipart upload type");
+        };
+
+        let stream = stream.map_err(std::io::Error::other);
+        let reader = tokio_util::io::StreamReader::new(stream);
+        let mut reader = std::pin::pin!(reader);
+        let mut result = String::new();
+        reader.read_to_string(&mut result).await.unwrap();
+
+        assert_eq!(result, content);
+    }
+
+    #[tokio::test]
+    async fn test_s3_upload_type_large_with_chunks() {
+        let content = "hello".repeat(1024 * 1024 * 5);
+        let input_chunks = std::iter::repeat(bytes::Bytes::from("hello"))
+            .map(eyre::Ok)
+            .take(1024 * 1024 * 5);
+        let input = futures::stream::iter(input_chunks);
+        let input = std::pin::pin!(input);
+        let upload_type = super::s3_upload_type(input).await.unwrap();
+
+        let super::S3UploadType::Multipart(stream) = upload_type else {
+            panic!("expected multipart upload type");
+        };
+
+        let stream = stream.map_err(std::io::Error::other);
+        let reader = tokio_util::io::StreamReader::new(stream);
+        let mut reader = std::pin::pin!(reader);
+        let mut result = String::new();
+        reader.read_to_string(&mut result).await.unwrap();
+
+        assert_eq!(result, content);
+    }
+
+    #[tokio::test]
+    async fn test_read_chunk_small_input_large_buffer() {
+        let input = futures::stream::iter([Ok::<_, std::io::Error>(bytes::Bytes::from("hello"))]);
+        let input = std::pin::pin!(input);
+        let mut buffer = [0; 1024];
+
+        let reader = tokio_util::io::StreamReader::new(input);
+        let mut reader = std::pin::pin!(reader);
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result = &buffer[..length];
+
+        assert_eq!(result, b"hello");
+    }
+
+    #[tokio::test]
+    async fn test_read_chunk_small_input_small_buffer() {
+        let input = futures::stream::iter([Ok::<_, std::io::Error>(bytes::Bytes::from("hello"))]);
+        let input = std::pin::pin!(input);
+        let mut buffer = [0; 3];
+
+        let reader = tokio_util::io::StreamReader::new(input);
+        let mut reader = std::pin::pin!(reader);
+
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result_1 = buffer[..length].to_vec();
+
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result_2 = buffer[..length].to_vec();
+
+        assert_eq!(result_1, b"hel");
+        assert_eq!(result_2, b"lo");
+    }
+
+    #[tokio::test]
+    async fn test_read_chunk_big_input_small_buffer() {
+        let input = futures::stream::iter([
+            Ok::<_, std::io::Error>(bytes::Bytes::from("hello")),
+            Ok(bytes::Bytes::from("world")),
+        ]);
+        let input = std::pin::pin!(input);
+        let mut buffer = [0; 3];
+
+        let reader = tokio_util::io::StreamReader::new(input);
+        let mut reader = std::pin::pin!(reader);
+
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result_1 = buffer[..length].to_vec();
+
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result_2 = buffer[..length].to_vec();
+
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result_3 = buffer[..length].to_vec();
+
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result_4 = buffer[..length].to_vec();
+
+        assert_eq!(result_1, b"hel");
+        assert_eq!(result_2, b"low");
+        assert_eq!(result_3, b"orl");
+        assert_eq!(result_4, b"d");
+    }
+
+    #[tokio::test]
+    async fn test_read_chunk_big_input_big_buffer() {
+        let input = futures::stream::iter([
+            Ok::<_, std::io::Error>(bytes::Bytes::from("hello")),
+            Ok(bytes::Bytes::from("world")),
+        ]);
+        let input = std::pin::pin!(input);
+        let mut buffer = [0; 1024];
+
+        let reader = tokio_util::io::StreamReader::new(input);
+        let mut reader = std::pin::pin!(reader);
+
+        let length = super::read_chunk(&mut reader, &mut buffer).await.unwrap();
+        let result = &buffer[..length];
+
+        assert_eq!(result, b"helloworld");
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -498,7 +498,7 @@ async fn put_blob_handler(
         .child("blobs")
         .child(blob_id.to_string());
 
-    // Return an error if the blob doesn't exist
+    // Return an error if the blob already exists
 
     let head = state.object_store.head(&blob_path).await;
     match head {

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,9 +84,7 @@ pub async fn start_server(state: Arc<ServerState>, addr: &SocketAddr) -> eyre::R
         )
         .route(
             "/v0/blobs/:blob_id",
-            axum::routing::get(get_blob_handler)
-                .head(head_blob_handler)
-                .put(put_blob_handler),
+            axum::routing::get(get_blob_handler).put(put_blob_handler),
         )
         .route(
             "/v0/artifacts/:artifact_hash",
@@ -391,28 +389,6 @@ async fn publish_project_handler(
         tags,
     };
     Ok((axum::http::StatusCode::CREATED, axum::Json(response)))
-}
-
-async fn head_blob_handler(
-    axum::extract::State(state): axum::extract::State<Arc<ServerState>>,
-    axum::extract::Path(blob_id): axum::extract::Path<BlobId>,
-) -> Result<axum::response::Response, ServerError> {
-    let blob_path = format!("blobs/{blob_id}");
-    if !state.object_store.exists(&blob_path).await? {
-        return Err(ServerError::NotFound);
-    }
-
-    // Build an empty body from a stream. Unlike `Body::empty()`, this
-    // ensures that the `Content-Length` header is not set.
-    const EMPTY: [Result<axum::body::Bytes, ServerError>; 0] = [];
-    let body = Body::from_stream(futures::stream::iter(EMPTY));
-
-    let response = axum::response::Response::builder()
-        .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
-        .header(axum::http::header::TRANSFER_ENCODING, "chunked")
-        .body(body)
-        .map_err(ServerError::other)?;
-    Ok(response)
 }
 
 async fn get_blob_handler(

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,6 @@ use eyre::{Context as _, OptionExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use joinery::JoinableIterator as _;
 use sqlx::Arguments as _;
-use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _};
 use tracing::Span;
 
 pub async fn start_server(state: Arc<ServerState>, addr: &SocketAddr) -> eyre::Result<()> {
@@ -137,33 +136,15 @@ async fn shutdown_signal() {
 pub struct ServerState {
     env: super::ServerEnv,
     proxy_layers: usize,
-    object_store: Box<dyn object_store::ObjectStore>,
-    object_store_path: object_store::path::Path,
+    object_store: crate::object_store::ObjectStore,
     pub db_pool: sqlx::SqlitePool,
 }
 
 impl ServerState {
     pub async fn new(env: super::ServerEnv) -> eyre::Result<Self> {
         // Handle the special `relative-file` URL (primarily for development)
-        let object_store_url = match env.object_store_url.scheme() {
-            "relative-file" => {
-                let relative_path = env.object_store_url.path();
-                let relative_path = relative_path.strip_prefix('/').unwrap_or(relative_path);
-                let abs_path = tokio::fs::canonicalize(std::path::Path::new(relative_path))
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "failed to canonicalize relative object store path: {relative_path}"
-                        )
-                    })?;
-                url::Url::from_directory_path(abs_path)
-                    .map_err(|_| eyre::eyre!("failed to create object store URL"))?
-            }
-            _ => env.object_store_url.clone(),
-        };
-        let object_store_opts = std::env::vars().map(|(k, v)| (k.to_ascii_lowercase(), v));
-        let (object_store, object_store_path) =
-            object_store::parse_url_opts(&object_store_url, object_store_opts)?;
+        let object_store =
+            crate::object_store::ObjectStore::from_url(&env.object_store_url).await?;
 
         let db_opts = sqlx::sqlite::SqliteConnectOptions::from_str(&env.database_url)?
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
@@ -182,7 +163,6 @@ impl ServerState {
             env,
             proxy_layers,
             object_store,
-            object_store_path,
             db_pool,
         })
     }
@@ -255,34 +235,25 @@ async fn publish_project_handler(
 ) -> Result<(axum::http::StatusCode, axum::Json<PublishProjectResponse>), ServerError> {
     let mut new_files = 0;
     for (file_id, file_contents) in &project_listing.files {
-        let file_path = state
-            .object_store_path
-            .child("blobs")
-            .child(file_id.to_string());
-        let head_result = state.object_store.head(&file_path).await;
+        let file_path = format!("blobs/{file_id}");
 
-        match head_result {
-            Ok(_) => {
-                // File already uploaded, so ignore
-                continue;
-            }
-            Err(object_store::Error::NotFound { .. }) => {
-                // File does not exist, so upload
-            }
-            Err(error) => {
-                return Err(ServerError::other(
-                    eyre::Error::new(error)
-                        .wrap_err("failed to check if project file already exists"),
-                ));
-            }
+        if state.object_store.exists(&file_path).await? {
+            // Skip blob if it already exists
+            continue;
         }
 
+        let file_contents_stream =
+            futures::stream::once(async { eyre::Ok(bytes::Bytes::copy_from_slice(file_contents)) });
+
+        let expected_hash = file_id
+            .as_blob_id()
+            .map_err(|error| eyre::eyre!(error))
+            .map_err(ServerError::other)?
+            .to_blake3();
         state
             .object_store
-            .put(&file_path, bytes::Bytes::copy_from_slice(file_contents))
-            .await
-            .wrap_err("failed to upload new project file")
-            .map_err(ServerError::other)?;
+            .put_and_validate(&file_path, file_contents_stream, expected_hash)
+            .await?;
 
         new_files += 1;
     }
@@ -426,25 +397,15 @@ async fn head_blob_handler(
     axum::extract::State(state): axum::extract::State<Arc<ServerState>>,
     axum::extract::Path(blob_id): axum::extract::Path<BlobId>,
 ) -> Result<axum::response::Response, ServerError> {
-    let blob_path = state
-        .object_store_path
-        .child("blobs")
-        .child(blob_id.to_string());
-    let object = state.object_store.head(&blob_path).await;
-    let body = match object {
-        Ok(_) => {
-            // Build an empty body from a stream. Unlike `Body::empty()`, this
-            // ensures that the `Content-Length` header is not set.
-            const EMPTY: [Result<axum::body::Bytes, ServerError>; 0] = [];
-            Body::from_stream(futures::stream::iter(EMPTY))
-        }
-        Err(object_store::Error::NotFound { .. }) => {
-            return Err(ServerError::NotFound);
-        }
-        Err(error) => {
-            return Err(ServerError::other(error));
-        }
-    };
+    let blob_path = format!("blobs/{blob_id}");
+    if !state.object_store.exists(&blob_path).await? {
+        return Err(ServerError::NotFound);
+    }
+
+    // Build an empty body from a stream. Unlike `Body::empty()`, this
+    // ensures that the `Content-Length` header is not set.
+    const EMPTY: [Result<axum::body::Bytes, ServerError>; 0] = [];
+    let body = Body::from_stream(futures::stream::iter(EMPTY));
 
     let response = axum::response::Response::builder()
         .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
@@ -458,33 +419,8 @@ async fn get_blob_handler(
     axum::extract::State(state): axum::extract::State<Arc<ServerState>>,
     axum::extract::Path(blob_id): axum::extract::Path<BlobId>,
 ) -> Result<axum::response::Response, ServerError> {
-    let blob_path = state
-        .object_store_path
-        .child("blobs")
-        .child(blob_id.to_string());
-    let object = state.object_store.get(&blob_path).await;
-    let object = match object {
-        Ok(object) => object,
-        Err(object_store::Error::NotFound { .. }) => {
-            return Err(ServerError::NotFound);
-        }
-        Err(error) => {
-            return Err(ServerError::other(error));
-        }
-    };
-
-    let body = match object.payload {
-        object_store::GetResultPayload::File(file, _) => {
-            let file = tokio::fs::File::from_std(file);
-            let stream = tokio_util::io::ReaderStream::new(file);
-            axum::body::Body::from_stream(stream)
-        }
-        object_store::GetResultPayload::Stream(stream) => axum::body::Body::from_stream(stream),
-    };
-    let response = axum::response::Response::builder()
-        .header(axum::http::header::CONTENT_TYPE, "application/octet-stream")
-        .body(body)
-        .map_err(ServerError::other)?;
+    let blob_key = format!("blobs/{blob_id}");
+    let response = state.object_store.get_as_http_response(&blob_key).await?;
     Ok(response)
 }
 
@@ -493,194 +429,21 @@ async fn put_blob_handler(
     axum::extract::Path(blob_id): axum::extract::Path<BlobId>,
     body: axum::body::Body,
 ) -> Result<(axum::http::StatusCode, axum::Json<BlobId>), ServerError> {
-    let blob_path = state
-        .object_store_path
-        .child("blobs")
-        .child(blob_id.to_string());
+    let blob_key = format!("blobs/{blob_id}");
 
     // Return an error if the blob already exists
 
-    let head = state.object_store.head(&blob_path).await;
-    match head {
-        Ok(_) => {
-            return Err(ServerError::AlreadyExists);
-        }
-        Err(object_store::Error::NotFound { .. }) => {
-            // Object doesn't exist, so we can create it
-        }
-        Err(error) => {
-            return Err(ServerError::other(error));
-        }
+    if state.object_store.exists(&blob_key).await? {
+        return Err(ServerError::AlreadyExists);
     }
 
-    // Start a multipart upload to the object store. We do this so we can
-    // hash the blob while we upload it, then cancel the upload if we discover
-    // the hash doesn't match.
-    // NOTE: Past this point, we shouldn't return early before calling
-    // `abort_multipart` for the object (to abort the upload) or calling
-    // `finalize` on the writer (to finish the upload).
+    let body_stream = body.into_data_stream();
+    let expected_hash = blob_id.to_blake3();
 
-    let (multipart_id, mut object_writer) = state
+    state
         .object_store
-        .put_multipart(&blob_path)
-        .await
-        .map_err(ServerError::other)?;
-
-    let (hasher_tx, mut hasher_rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(10);
-    let (uploader_tx, uploader_rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(10);
-
-    // Create a task that hashes each chunk of the blob as we receive it
-    let hasher_task = tokio::task::spawn_blocking(move || {
-        let mut hasher = blake3::Hasher::new();
-        while let Some(bytes) = hasher_rx.blocking_recv() {
-            hasher.update(&bytes[..]);
-        }
-
-        hasher.finalize()
-    });
-
-    // Create a task to upload each chunk of the blob
-    let uploader_task = tokio::spawn(async move {
-        // Create a buffered reader from the bytes from the receiver. We use
-        // a size of 1MB because each buffered chunk should get uploaded as a
-        // separate `PUT` request.
-        let uploader_stream =
-            tokio_stream::wrappers::ReceiverStream::new(uploader_rx).map(Ok::<_, std::io::Error>);
-        let uploader_reader = tokio_util::io::StreamReader::new(uploader_stream);
-        let mut uploader_reader = tokio::io::BufReader::with_capacity(1024 * 1024, uploader_reader);
-
-        loop {
-            // Read a chunk from the receiver, up to the buffer size
-            let chunk = uploader_reader.fill_buf().await?;
-            let chunk_len = chunk.len();
-
-            // A length of 0 means we've reached the end
-            if chunk_len == 0 {
-                break;
-            }
-
-            // Write the buffered chunk
-            object_writer
-                .write_all(chunk)
-                .await
-                .wrap_err("failed to write blob chunk")?;
-
-            // Consume the bytes we just read from the buffered reader
-            uploader_reader.consume(chunk_len);
-        }
-
-        eyre::Ok(object_writer)
-    });
-
-    let mut body_stream = body.into_data_stream();
-    let result = loop {
-        let Some(bytes) = body_stream.next().await else {
-            break Ok(());
-        };
-
-        let bytes = match bytes {
-            Ok(bytes) => bytes,
-            Err(error) => {
-                break Err(ServerError::other(error));
-            }
-        };
-
-        // Send the bytes to both the hasher and the uploader tasks
-
-        match hasher_tx.send(bytes.clone()).await {
-            Ok(()) => {}
-            Err(error) => {
-                break Err(ServerError::other(error));
-            }
-        };
-        match uploader_tx.send(bytes).await {
-            Ok(()) => {}
-            Err(error) => {
-                break Err(ServerError::other(error));
-            }
-        }
-    };
-
-    // Close the channels by dropping them
-    drop(hasher_tx);
-    drop(uploader_tx);
-
-    // Abort the multipart upload if we encountered an error reading from
-    // the body
-    if let Err(error) = result {
-        let _ = state
-            .object_store
-            .abort_multipart(&blob_path, &multipart_id)
-            .await
-            .inspect_err(|error| {
-                tracing::warn!(?blob_path, %error, "failed to abort multipart upload");
-            });
-        return Err(error);
-    }
-
-    // Wait for the hasher to finish (aborting the mutlipart upload if it failed)
-    let actual_hash = match hasher_task.await {
-        Ok(hash) => hash,
-        Err(error) => {
-            let _ = state
-                .object_store
-                .abort_multipart(&blob_path, &multipart_id)
-                .await
-                .inspect_err(|error| {
-                    tracing::warn!(?blob_path, %error, "failed to abort multipart upload");
-                });
-            return Err(ServerError::other(error));
-        }
-    };
-
-    // Wait for the uploader task to finish (aborting the multipart upload
-    // if it fails). If it succeeds, we get the object writer back so we can
-    // flush it.
-    let uploader_task_result = uploader_task
-        .await
-        .map_err(eyre::Error::from)
-        .and_then(|result| result);
-    let mut object_writer = match uploader_task_result {
-        Ok(object_writer) => object_writer,
-        Err(error) => {
-            let _ = state
-                .object_store
-                .abort_multipart(&blob_path, &multipart_id)
-                .await
-                .inspect_err(|error| {
-                    tracing::warn!(?blob_path, %error, "failed to abort multipart upload");
-                });
-            return Err(ServerError::other(error));
-        }
-    };
-
-    // Validate the hash of the blob matches the request
-    let actual_blob_id = BlobId::from_blake3(actual_hash);
-    if blob_id != actual_blob_id {
-        state
-            .object_store
-            .abort_multipart(&blob_path, &multipart_id)
-            .await
-            .inspect_err(|error| {
-                tracing::warn!(?blob_path, %error, "failed to abort multipart upload");
-            })
-            .map_err(ServerError::other)?;
-        return Err(ServerError::BadRequest(Cow::Owned(format!(
-            "blob hash mismatch: expected {blob_id}, got {actual_blob_id}"
-        ))));
-    }
-
-    // Flush the stream and shutdown the writer to ensure we finish the
-    // multipart upload
-    object_writer
-        .flush()
-        .await
-        .wrap_err("failed to flush blob writer")
-        .map_err(ServerError::other)?;
-    object_writer
-        .shutdown()
-        .await
-        .wrap_err("failed to shutdown blob writer")?;
+        .put_and_validate(&blob_key, body_stream, expected_hash)
+        .await?;
 
     Ok((axum::http::StatusCode::CREATED, axum::Json(blob_id)))
 }
@@ -862,19 +625,12 @@ async fn known_blobs_handler(
             let state = state.clone();
             let tx = tx.clone();
             async move {
-                let blob_path = state
-                    .object_store_path
-                    .child("blobs")
-                    .child(blob_id.to_string());
-                let head = state.object_store.head(&blob_path).await;
-                match head {
-                    Ok(_) => {
-                        tx.send(blob_id).await.map_err(ServerError::other)?;
-                        Ok(())
-                    }
-                    Err(object_store::Error::NotFound { .. }) => Ok(()),
-                    Err(error) => Err(ServerError::other(error)),
+                let blob_key = format!("blobs/{blob_id}");
+                if state.object_store.exists(&blob_key).await? {
+                    tx.send(blob_id).await.map_err(ServerError::other)?;
                 }
+
+                Ok::<_, ServerError>(())
             }
         })
         .await?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -396,7 +396,11 @@ async fn get_blob_handler(
     axum::extract::Path(blob_id): axum::extract::Path<BlobId>,
 ) -> Result<axum::response::Response, ServerError> {
     let blob_key = format!("blobs/{blob_id}");
-    let response = state.object_store.get_as_http_response(&blob_key).await?;
+    let response = state
+        .object_store
+        .try_get_as_http_response(&blob_key)
+        .await?;
+    let response = response.ok_or_else(|| ServerError::NotFound)?;
     Ok(response)
 }
 


### PR DESCRIPTION
This PR replaces the use of the [`object_store`](https://crates.io/crates/object_store) crate with a custom module (also called `object_store`). This new module has custom implementations for reading/writing objects to the filesystem and to S3-compatible backends using the official [`aws-sdk-s3`](https://crates.io/crates/aws-sdk-s3) crate. This PR also undoes some of the object store-related changes from #3 (hashing and uploading are again done in the same task instead of trying to use separate tasks for each).

This PR will likely require some env var changes when using an S3-compatible backend. To use an S3-compatible backend, `BRIOCHE_REGISTRY_OBJECT_STORE_URL` must be set to a URL of the format `s3://<bucket_name>/<prefix>` (the `object_store` crate was more lenient and allowed using some forms of `http[s]://` URLs). To use a custom S3-compatible provider, the env var `AWS_ENDPOINT_URL_S3` can be set.

One immediate outcome of this change: `GET /v0/blobs/:blob_id` requests now return a redirect to a pre-signed URL! This should overall save bandwidth as the caller can download directly from the S3 storage provider. The `object_store` crate made this possible, but it was somewhat more difficult than using a bespoke implementation.