### PR TITLE
Add env var to serve blobs from a different public URL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ struct ServerEnv {
     object_store_url: url::Url,
     password_hash: String,
     proxy_layers: Option<usize>,
+    public_object_store_base_url: Option<url::Url>,
 }
 
 async fn migrate() -> eyre::Result<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -162,9 +162,12 @@ pub struct ServerState {
 
 impl ServerState {
     pub async fn new(env: super::ServerEnv) -> eyre::Result<Self> {
-        // Handle the special `relative-file` URL (primarily for development)
         let object_store =
-            crate::object_store::ObjectStore::from_url(&env.object_store_url).await?;
+            crate::object_store::ObjectStore::new(crate::object_store::ObjectStoreConfig {
+                url: env.object_store_url.clone(),
+                public_base_url: env.public_object_store_base_url.clone(),
+            })
+            .await?;
 
         let db_opts = sqlx::sqlite::SqliteConnectOptions::from_str(&env.database_url)?
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);


### PR DESCRIPTION
This PR updates the registry so blobs can now be served from a different URL from where they are stored to. If the env var `$BRIOCHE_REGISTRY_PUBLIC_OBJECT_STORE_BASE_URL` is set, then all blob reads will be redirected to that URL joined with the blob key.

The main motivation is for the official registry's usage of Cloudflare R2. It turns out R2 only uses a single region, and can't be cached unless it's a public bucket. And, a bucket can only be public and cached if it's hosted through a custom domain. So I've already configured a new custom domain for the R2 bucket used for blobs, and now `$BRIOCHE_REGISTRY_PUBLIC_OBJECT_STORE_BASE_URL` is set to that domain. This should allow Cloudflare to cache blobs across regions.