### PR TITLE
build: update Rust to 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "brioche-registry"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88"     # To align with the rust-toolchain.toml
+rust-version = "1.89"     # To align with the rust-toolchain.toml
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88.0-bookworm AS builder
+FROM rust:1.89.0-bookworm AS builder
 
 WORKDIR /src/brioche-registry
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"
 profile = "default"


### PR DESCRIPTION
I just bump Rust version to 1.89. I know there is no need to bump the Semver in `Cargo.toml`, but it's just to uniformize everything and ensure everyone is using the latest version available. At the end, this is a binary and not a library, so bumping Semver is not dramatic.

PS: No new lints were detected by Clippy.