### PR TITLE
build: update Rust version to 1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "brioche-registry"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.89"     # To align with the rust-toolchain.toml
+rust-version = "1.90"     # To align with the rust-toolchain.toml
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.89.0-bookworm AS builder
+FROM rust:1.90.0-bookworm AS builder
 
 WORKDIR /src/brioche-registry
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90.0-bookworm AS builder
+FROM rust:1.90.0-trixie AS builder
 
 WORKDIR /src/brioche-registry
 
@@ -8,14 +8,14 @@ COPY migrations migrations
 COPY .sqlx .sqlx
 RUN cargo install --locked --path . --root /app
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 COPY --from=builder /app/bin/brioche-registry /usr/local/bin/brioche-registry
 
 ENV DEBIAN_FRONTEND=O
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y bash=5.2.15-2+b8 curl=7.88.1-10+deb12u12 fuse3=3.14.0-4 sqlite3=3.40.1-2+deb12u1 ca-certificates=20230311; \
+    apt-get install -y bash=5.2.37-2+b5 curl=8.14.1-2 fuse3=3.17.2-3 sqlite3=3.46.1-7 ca-certificates=20250419; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90.0-trixie AS builder
+FROM docker.io/library/rust:1.90.0-trixie AS builder
 
 WORKDIR /src/brioche-registry
 
@@ -8,7 +8,7 @@ COPY migrations migrations
 COPY .sqlx .sqlx
 RUN cargo install --locked --path . --root /app
 
-FROM debian:trixie-slim
+FROM docker.io/library/debian:trixie-slim
 
 COPY --from=builder /app/bin/brioche-registry /usr/local/bin/brioche-registry
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89"
+channel = "1.90"
 profile = "default"


### PR DESCRIPTION
Update Rust to [its latest version 1.90.0](https://doc.rust-lang.org/stable/releases.html) which leads faster build time. There is no new lints detected by Clippy 🚀